### PR TITLE
Grant INTERNET, ACCESS_NETWORK_STATE permissions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     project.ext {
         compileSdkVersion = 29
         minSdkVersion = 21
-        targetSdkVersion = 21
+        targetSdkVersion = 23
         versionCode = 7
         versionName = "1.4.0"
         buildToolsVersion = '27.0.3'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,8 @@ allprojects {
     project.ext {
         compileSdkVersion = 29
         minSdkVersion = 21
-        targetSdkVersion = 23
+        targetSdkVersion = 23  // The minimum version that doesn't break MIUI.
+                               // See https://github.com/joaomgcd/TaskerSettings/pull/13
         versionCode = 7
         versionName = "1.4.0"
         buildToolsVersion = '27.0.3'


### PR DESCRIPTION
_Might_ solve #6 and [my own thread here](https://groups.google.com/u/1/g/tasker/c/1hYPrHJxZFQ).

The idea is to make Tasker Settings ask for the _permanent_ "Change WiFi Connectivity permission" under MIUI specifically.

According to this random Chinese article, the two permissions I added might just be the missing ones.
https://blog.csdn.net/u014632228/article/details/101207983

I tried to verify it by myself but when building locally, I couldn't install the APK because of some package conflict (I guess that because TaskerSettings interferes somehow with the Tasker package, and I can't sign on @joaomgcd's behalf 🙂).
